### PR TITLE
Update api.go and README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,14 @@ WaitForCommitmentStatus(
 ) (MonitorResponse, error)
 ```
 
+## API Urls
+
+This library provides two options to leverage for Jupiter APIs. 
+
+The default API leverages [jupiterapi.com](https://www.jupiterapi.com/) (Community Project). This endpoint provides higher rate limits, but includes a small 0.2% platform fee. This API can be used via `jupiter.DefaultAPIURL`.
+
+The Jupiter API provided by the official Jupiter team can be used via `jupiter.JupiterAPIURL`.
+
 ## License
 
 This library is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.

--- a/jupiter/api.go
+++ b/jupiter/api.go
@@ -1,3 +1,4 @@
 package jupiter
 
-const DefaultAPIURL = "https://quote-api.jup.ag/v6"
+const DefaultAPIURL = "https://public.jupiterapi.com"
+const JupiterAPIURL = "https://quote-api.jup.ag/v6"


### PR DESCRIPTION
This PR adjusts the API constants provided for the jupiter package. The default API was updated for swap/quote to leverage [jupiterapi.com](https://www.jupiterapi.com/). The API offers higher rate limits along with a faster updated market cache. The [jupiterapi.com](https://www.jupiterapi.com/) market cache surfaces newly launched tokens faster since it doesn't require a certain volume/liquidity threshold to be met, along with an improved cadence of it being updated. With that said, the API does take a small fee on swaps given the stability/rate limits/new markets it provides. More details can be found on their site.

I also updated the README.md to provide options to other endpoints in case higher rate limits are needed.