### PR TITLE
refactor: update API endpoints and documentation for new structure

### DIFF
--- a/jupiter/api.go
+++ b/jupiter/api.go
@@ -3,5 +3,5 @@ package jupiter
 const (
 	// DefaultAPIURL is the default Jupiter API provided by the official Jupiter team.
 	// For more info visit: https://dev.jup.ag/docs#whats-new
-	DefaultAPIURL = "https://lite-api.jup.ag"
+	DefaultAPIURL = "https://lite-api.jup.ag/swap/v1"
 )

--- a/jupiter/client.gen.go
+++ b/jupiter/client.gen.go
@@ -256,7 +256,7 @@ type QuoteGetParams struct {
 	Amount      AmountParameter    `form:"amount" json:"amount"`
 	SlippageBps *SlippageParameter `form:"slippageBps,omitempty" json:"slippageBps,omitempty"`
 
-	// SwapMode - ExactOut is for supporting use cases where you need an exact output amount, like https://station.jup.ag/docs/swap-api/payments-through-swap
+	// SwapMode - ExactOut is for supporting use cases where you need an exact output amount, like using [Swap API as a payment service](/docs/swap-api/payments-through-swap)
 	// - In the case of `ExactIn`, the slippage is on the output token
 	// - In the case of `ExactOut`, the slippage is on the input token
 	// - Not all AMMs support `ExactOut`
@@ -265,13 +265,13 @@ type QuoteGetParams struct {
 	// Dexes - Multiple DEXes can be pass in by comma separating them
 	// - For example: `dexes=Raydium,Orca+V2,Meteora+DLMM`
 	// - If a DEX is indicated, the route will **only use** that DEX
-	// - [Full list of DEXes here](https://api.jup.ag/swap/v1/program-id-to-label)
+	// - [Full list of DEXes here](https://lite-api.jup.ag/swap/v1/program-id-to-label)
 	Dexes *DexesParameter `form:"dexes,omitempty" json:"dexes,omitempty"`
 
 	// ExcludeDexes - Multiple DEXes can be pass in by comma separating them
 	// - For example: `excludeDexes=Raydium,Orca+V2,Meteora+DLMM`
 	// - If a DEX is indicated, the route will **not use** that DEX
-	// - [Full list of DEXes here](https://api.jup.ag/swap/v1/program-id-to-label)
+	// - [Full list of DEXes here](https://lite-api.jup.ag/swap/v1/program-id-to-label)
 	ExcludeDexes *ExcludeDexesParameter `form:"excludeDexes,omitempty" json:"excludeDexes,omitempty"`
 
 	// RestrictIntermediateTokens - Restrict intermediate tokens within a route to a set of more stable tokens
@@ -478,7 +478,7 @@ func NewProgramIdToLabelGetRequest(server string) (*http.Request, error) {
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/swap/v1/program-id-to-label")
+	operationPath := fmt.Sprintf("/program-id-to-label")
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -505,7 +505,7 @@ func NewQuoteGetRequest(server string, params *QuoteGetParams) (*http.Request, e
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/swap/v1/quote")
+	operationPath := fmt.Sprintf("/quote")
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -745,7 +745,7 @@ func NewSwapPostRequestWithBody(server string, contentType string, body io.Reade
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/swap/v1/swap")
+	operationPath := fmt.Sprintf("/swap")
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -785,7 +785,7 @@ func NewSwapInstructionsPostRequestWithBody(server string, contentType string, b
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/swap/v1/swap-instructions")
+	operationPath := fmt.Sprintf("/swap-instructions")
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}

--- a/jupiter/client.gen.go
+++ b/jupiter/client.gen.go
@@ -207,7 +207,7 @@ type SwapResponse struct {
 }
 
 // AmountParameter defines model for AmountParameter.
-type AmountParameter = int
+type AmountParameter = int64
 
 // AsLegacyTransactionParameter defines model for AsLegacyTransactionParameter.
 type AsLegacyTransactionParameter = bool

--- a/jupiter/openapi/jupiter-swagger.yaml
+++ b/jupiter/openapi/jupiter-swagger.yaml
@@ -6,7 +6,7 @@ info:
     The heart and soul of Jupiter lies in the Quote and Swap API.
 
     ### API Rate Limit
-    Since 1 December 2024, we have updated our API structure. Please refer to [Station](https://station.jup.ag/docs/) for further details on usage and rate limits.
+    Since 1 December 2024, we have updated our API structure. Please refer to [Developer Docs](https://dev.jup.ag/docs/) for further details on usage and rate limits.
 
     ### API Usage
     - API Wrapper Typescript [@jup-ag/api](https://github.com/jup-ag/jupiter-quote-api-node)
@@ -16,10 +16,13 @@ info:
     - Raw data such as Vec<u8\> are base64 encoded strings
 
 servers:
-  - url: https://api.jup.ag
+  - url: https://lite-api.jup.ag/swap/v1
+    description: Free tier API endpoint with rate limits
+  - url: https://api.jup.ag/swap/v1
+    description: Paid tier API endpoint with higher rate limits to be used with an API Key
 
 paths:
-  /swap/v1/quote:
+  /quote:
     get:
       operationId: QuoteGet
       tags:
@@ -27,9 +30,9 @@ paths:
       summary: quote
       description: |
         Request for a quote to be used in `POST /swap`
-        
+
         :::note
-        Refer to https://station.jup.ag/docs/swap-api/get-quote for more information
+        Refer to [Swap API doc](https://dev.jup.ag/docs/swap-api/get-quote) for more information
         :::
       parameters:
         - $ref: '#/components/parameters/InputMintParameter'
@@ -47,21 +50,22 @@ paths:
         - $ref: '#/components/parameters/DynamicSlippage'
       responses:
         '200':
-          description: "Successful response to be used in `/swap`"
+          description: 'Successful response to be used in `/swap`'
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/QuoteResponse'
-  /swap/v1/swap:
+  /swap:
     post:
       operationId: SwapPost
       tags:
         - Swap
+      summary: swap
       description: |
         Request for a base64-encoded unsigned swap transaction based on the `/quote` response
-        
+
         :::note
-        Refer to https://station.jup.ag/docs/swap-api/build-swap-transaction for more information
+        Refer to [Swap API doc](https://dev.jup.ag/docs/swap-api/build-swap-transaction) for more information
         :::
       requestBody:
         required: true
@@ -76,7 +80,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SwapResponse'
-  /swap/v1/swap-instructions:
+  /swap-instructions:
     post:
       operationId: SwapInstructionsPost
       tags:
@@ -84,9 +88,9 @@ paths:
       summary: swap-instructions
       description: |
         Request for swap instructions that you can use from the quote you get from `/quote`
-        
+
         :::note
-        Refer to https://station.jup.ag/docs/swap-api/build-swap-transaction#build-your-own-transaction-with-instructions for more information
+        Refer to [Swap API doc](https://dev.jup.ag/docs/swap-api/build-swap-transaction#build-your-own-transaction-with-instructions) for more information
         :::
       requestBody:
         required: true
@@ -101,11 +105,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SwapInstructionsResponse'
-  /swap/v1/program-id-to-label:
+  /program-id-to-label:
     get:
       operationId: ProgramIdToLabelGet
       tags:
         - Swap
+      summary: program-id-to-label
       description: |
         Returns a hash, which key is the program id and value is the label.
         This is used to help map error from transaction by identifying the fault program id.
@@ -468,7 +473,6 @@ components:
       required: true
       schema:
         type: integer
-        format: int64
     SlippageParameter:
       name: slippageBps
       in: query
@@ -477,7 +481,7 @@ components:
     SwapModeParameter:
       name: swapMode
       description: |
-        - ExactOut is for supporting use cases where you need an exact output amount, like https://station.jup.ag/docs/swap-api/payments-through-swap
+        - ExactOut is for supporting use cases where you need an exact output amount, like using [Swap API as a payment service](/docs/swap-api/payments-through-swap)
         - In the case of `ExactIn`, the slippage is on the output token
         - In the case of `ExactOut`, the slippage is on the input token
         - Not all AMMs support `ExactOut`
@@ -494,7 +498,7 @@ components:
         - Multiple DEXes can be pass in by comma separating them
         - For example: `dexes=Raydium,Orca+V2,Meteora+DLMM`
         - If a DEX is indicated, the route will **only use** that DEX
-        - [Full list of DEXes here](https://api.jup.ag/swap/v1/program-id-to-label)
+        - [Full list of DEXes here](https://lite-api.jup.ag/swap/v1/program-id-to-label)
       in: query
       schema:
         type: array
@@ -506,7 +510,7 @@ components:
         - Multiple DEXes can be pass in by comma separating them
         - For example: `excludeDexes=Raydium,Orca+V2,Meteora+DLMM`
         - If a DEX is indicated, the route will **not use** that DEX
-        - [Full list of DEXes here](https://api.jup.ag/swap/v1/program-id-to-label)
+        - [Full list of DEXes here](https://lite-api.jup.ag/swap/v1/program-id-to-label)
       in: query
       schema:
         type: array

--- a/jupiter/openapi/jupiter-swagger.yaml
+++ b/jupiter/openapi/jupiter-swagger.yaml
@@ -473,6 +473,7 @@ components:
       required: true
       schema:
         type: integer
+        format: int64
     SlippageParameter:
       name: slippageBps
       in: query


### PR DESCRIPTION
- Changed DefaultAPIURL to point to the new swap version endpoint.
- Updated various API paths to remove the versioning from the URL.
- Revised comments and documentation links to reflect the new API structure and provide clearer references.


